### PR TITLE
PILOT-1292 Add init containers to Metadata service

### DIFF
--- a/metadata-service/templates/deployment.yaml
+++ b/metadata-service/templates/deployment.yaml
@@ -35,23 +35,11 @@ spec:
       serviceAccountName: {{ include "metadata-service.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      containers:
-        - name: {{ .Chart.Name }}
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          env:
-          - name: port
-            value: {{ .Values.appConfig.port | quote }}
-          - name: CONFIG_CENTER_ENABLED
-            value: {{ .Values.appConfig.config_center_enabled | quote }}
-          - name: CONFIG_CENTER_BASE_URL
-            value: {{ .Values.appConfig.config_center_base_url | quote }}
-          - name: env
-            value: {{ .Values.appConfig.env | quote }}
-          - name: srv_namespace
-            value: {{ .Values.appConfig.srv_namespace | quote }}             
+      initContainers:
+        - name: "init{{ .Values.name }}"
+            image: "{{ .Values.image.repository }}:alembic-{{ .Values.image.tag | default .Chart.AppVersion }}"
+            imagePullPolicy: {{ .Values.image.pullPolicy }}
+            env:        
 {{- if .Values.extraEnv }} 
   {{- range $key, $value := .Values.extraEnv }}
           - name: {{ $key }}
@@ -70,6 +58,23 @@ spec:
 {{- with .Values.extraEnvYaml }}
           {{- toYaml . | nindent 10 }}
 {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          - name: port
+            value: {{ .Values.appConfig.port | quote }}
+          - name: CONFIG_CENTER_ENABLED
+            value: {{ .Values.appConfig.config_center_enabled | quote }}
+          - name: CONFIG_CENTER_BASE_URL
+            value: {{ .Values.appConfig.config_center_base_url | quote }}
+          - name: env
+            value: {{ .Values.appConfig.env | quote }}
+          - name: srv_namespace
+            value: {{ .Values.appConfig.srv_namespace | quote }} 
           ports:
               - name: http
                 containerPort: {{ .Values.container.port }}
@@ -99,4 +104,3 @@ spec:
       volumes:
         {{- toYaml .Values.extraVolumes | nindent 10 }}
       {{- end }}  
-


### PR DESCRIPTION
Add init containers to Metadata service's `deployment.yaml`.

Related to https://github.com/PilotDataPlatform/metadata/pull/33.