### PR TITLE
PILOT-3296 Add SEEK_TO_BEGINNING to billing events

### DIFF
--- a/billing-monolith/events/values.yaml
+++ b/billing-monolith/events/values.yaml
@@ -12,6 +12,7 @@ image:
 appConfig:
   KAFKA_URI: "10.3.7.113:9092"
   CONSUMER_GROUP: "billing"
+  SEEK_TO_BEGINNING: true
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
- Add `SEEK_TO_BEGINNING` value to the billing monolith's event handler.
- This value should encourage the consumer to start at the beginning of the topic, solving the below bug.

https://indocconsortium.atlassian.net/browse/PILOT-3296