### PR TITLE
Possible modification to automatically delete created pod-jobs on com…

### DIFF
--- a/skiff-service/templates/cronjob.yaml
+++ b/skiff-service/templates/cronjob.yaml
@@ -8,6 +8,7 @@ spec:
   schedule: "{{ .Values.schedule }}"
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 10
       template:
         metadata:
           {{- with .Values.podAnnotations }}


### PR DESCRIPTION
After @vbezbakh-indocsystems mentioned this ,and following official documentation, https://kubernetes.io/docs/concepts/workloads/controllers/job/#clean-up-finished-jobs-automatically we could add this field to the cronjob template to ensure automaitc pod deletion after completion.
Pros:
We'll cleanup the Completed pods
Cons:
Reduces visibility in case of issue