### PR TITLE
PILOT-5114: Add virtual machines to workspace cluster role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ dmypy.json
 .pyre/
 
 .DS_Store
+
+# IntelliJ IDE
+.idea

--- a/workspace-service/templates/clusterrole.yaml
+++ b/workspace-service/templates/clusterrole.yaml
@@ -35,3 +35,15 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - compute.azure.com
+  resources:
+  - virtualmachines
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/workspace-service/templates/clusterrole.yaml
+++ b/workspace-service/templates/clusterrole.yaml
@@ -40,10 +40,5 @@ rules:
   resources:
   - virtualmachines
   verbs:
-  - create
-  - delete
   - get
   - list
-  - patch
-  - update
-  - watch


### PR DESCRIPTION
## Summary

- Add virtual machine resource to cluster role of workspace service
- Update `.gitignore` to include intellij related directory

## JIRA Issues

https://indocconsortium.atlassian.net/browse/PILOT-5114

## Type of Change

- [X] New feature (non-breaking change which adds functionality)

## Testing

Are there any new or updated tests to validate the changes?

- [ ] Yes
- [X] No

## Test Directions

- Service account of workspace service should be able to list azure virtual machines
