### PR TITLE
Patch20240617: update cli automation script

### DIFF
--- a/cli-automation-public-bucket/templates/job.yaml
+++ b/cli-automation-public-bucket/templates/job.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "cli-automation-public-bucket.labels" . | nindent 4 }}
 spec:
+  ttlSecondsAfterFinished: 120
   template:
     metadata:
       {{- with .Values.podAnnotations }}

--- a/cli-automation-pvc/templates/clusterrole-pvc.yaml
+++ b/cli-automation-pvc/templates/clusterrole-pvc.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "cli-automation-pvc.fullname" . }}-cli-pvc-cr
+  name: {{ include "cli-automation-pvc.fullname" . }}-{{ .Release.Namespace }}-cli-pvc-cr
 rules:
 - apiGroups: ["apps"]
   resources: ["deployments"]

--- a/cli-automation-pvc/templates/clusterrolebinding-pvc.yaml
+++ b/cli-automation-pvc/templates/clusterrolebinding-pvc.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "cli-automation-pvc.fullname" . }}-cli-pvc-crb
+  name: {{ include "cli-automation-pvc.fullname" . }}-{{ .Release.Namespace }}-cli-pvc-crb
 subjects:
 - kind: ServiceAccount
   name: {{ include "cli-automation-pvc.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: {{ include "cli-automation-pvc.fullname" . }}-cli-pvc-cr
+  name: {{ include "cli-automation-pvc.fullname" . }}-{{ .Release.Namespace }}-cli-pvc-cr
   apiGroup: rbac.authorization.k8s.io

--- a/cli-automation-pvc/templates/job.yaml
+++ b/cli-automation-pvc/templates/job.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "cli-automation-pvc.labels" . | nindent 4 }}
 spec:
+  ttlSecondsAfterFinished: 120
   template:
     metadata:
       {{- with .Values.podAnnotations }}


### PR DESCRIPTION
 - update role and rolebinding for cli-automation script to create an unique role between tenant
 - update script to have ttl when completion because `Job` type is an immutable schema in Kubernetes. See solution here: https://github.com/helm/helm/issues/7725#issuecomment-1038280907 