### PR TITLE
IEBH-345: handle OCI registry URLs in add chart script

### DIFF
--- a/add_chart_repo.sh
+++ b/add_chart_repo.sh
@@ -36,9 +36,15 @@ check_arguments() {
 
 extract_chart_name() {
     if [[ $1 == "--release" ]]; then
-      echo $2
+        echo $2
     else
-      echo $1 | cut -d "/" -f 2
+        if [[ $1 == oci://* ]]; then
+            # For OCI URLs, take the last segment
+            echo $1 | rev | cut -d "/" -f 1 | rev
+        else
+            # For regular helm repo charts
+            echo $1 | cut -d "/" -f 2
+        fi
     fi
 }
 


### PR DESCRIPTION
When using OCI registry URLs (e.g. oci://registry-1.docker.io/bitnamicharts/kafka), the chart name extraction was failing because it assumed a two-segment path. Modified extract_chart_name() to properly handle OCI URLs by extracting the last path segment as the chart name.