### PR TITLE
IEBH-319: add dataset-hdc chart

### DIFF
--- a/bff-hdc/Chart.yaml
+++ b/bff-hdc/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: "1471"
 description: A Helm chart for Kubernetes
 name: bff
 type: application
-version: 0.5.0
+version: 0.6.0

--- a/bff-hdc/templates/service.yaml
+++ b/bff-hdc/templates/service.yaml
@@ -13,10 +13,10 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
-      name: {{ include "bff.fullname" . }}
+      name: {{ .Values.service.portName | default (include "bff.fullname" .) }}
     - port: {{ .Values.service.portalPort }}
       targetPort: {{ .Values.service.portalTargetPort }}
       protocol: TCP
-      name: portal-{{ include "bff.fullname" . }}
+      name: {{ .Values.service.portalPortName | default (printf "portal-%s" (include "bff.fullname" .)) }}
   selector:
     {{- include "bff.selectorLabels" . | nindent 4 }}

--- a/bff-hdc/values.yaml
+++ b/bff-hdc/values.yaml
@@ -42,6 +42,8 @@ service:
   type: LoadBalancer
   port: 5060
   portalPort: 3000
+  portName: ""
+  portalPortName: ""
   # Additional custom labels can be added to the service
   # Example:
   #labels:

--- a/dataset-service-hdc/Chart.yaml
+++ b/dataset-service-hdc/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+appVersion: "25"
+description: A Helm chart for Kubernetes
+name: dataset-service
+type: application
+version: 0.4.0

--- a/dataset-service-hdc/Chart.yaml
+++ b/dataset-service-hdc/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: "25"
 description: A Helm chart for Kubernetes
 name: dataset-service
 type: application
-version: 0.4.0
+version: 0.5.0

--- a/dataset-service-hdc/dataset-service/.helmignore
+++ b/dataset-service-hdc/dataset-service/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/dataset-service-hdc/templates/NOTES.txt
+++ b/dataset-service-hdc/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "dataset-service.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "dataset-service.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "dataset-service.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "dataset-service.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/dataset-service-hdc/templates/_helpers.tpl
+++ b/dataset-service-hdc/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "dataset-service.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "dataset-service.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "dataset-service.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "dataset-service.labels" -}}
+helm.sh/chart: {{ include "dataset-service.chart" . }}
+{{ include "dataset-service.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "dataset-service.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "dataset-service.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "dataset-service.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "dataset-service.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/dataset-service-hdc/templates/deployment.yaml
+++ b/dataset-service-hdc/templates/deployment.yaml
@@ -1,0 +1,153 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "dataset-service.fullname" . }}
+  labels:
+    {{- include "dataset-service.labels" . | nindent 4 }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+    {{- if .Values.updateStrategy }}
+  strategy:
+    {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "dataset-service.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "dataset-service.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: "init{{ .Values.name }}"
+          image: "{{ .Values.image.repository }}:alembic-{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.initCommand }}
+          {{- with .Values.initCommand }}
+          command: 
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.initArgs }}
+          {{- with .Values.initArgs }}
+          args: 
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- end }}
+          env:
+          - name: CONFIG_CENTER_ENABLED
+            value: {{ .Values.appConfig.config_center_enabled | quote }}
+          - name: CONFIG_CENTER_BASE_URL
+            value: {{ .Values.appConfig.config_center_base_url | quote }}
+          - name: env
+            value: {{ .Values.appConfig.env | quote }}
+          - name: srv_namespace
+            value: {{ .Values.appConfig.srv_namespace | quote }}
+{{- if .Values.extraEnv }}
+  {{- range $key, $value := .Values.extraEnv }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+  {{- end }}
+{{- end }}
+{{- if .Values.envSecrets }}
+  {{- range $key, $secret :=  .Values.envSecrets }}
+          - name: {{ $key }}
+            valueFrom:
+              secretKeyRef:
+                name: {{ $secret }}
+                key: {{ $key | quote }}
+  {{- end }}
+{{- end }}
+{{- with .Values.extraEnvYaml }}
+          {{- toYaml . | nindent 10 }}
+{{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:dataset-{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.command }}
+          {{- with .Values.command }}
+          command: 
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.args }}
+          {{- with .Values.args }}
+          args: 
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- end }}
+          env:
+          - name: port
+            value: {{ .Values.appConfig.port | quote }}
+          - name: CONFIG_CENTER_ENABLED
+            value: {{ .Values.appConfig.config_center_enabled | quote }}
+          - name: CONFIG_CENTER_BASE_URL
+            value: {{ .Values.appConfig.config_center_base_url | quote }}
+          - name: env
+            value: {{ .Values.appConfig.env | quote }}
+          - name: srv_namespace
+            value: {{ .Values.appConfig.srv_namespace | quote }}
+{{- if .Values.extraEnv }}
+  {{- range $key, $value := .Values.extraEnv }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+  {{- end }}
+{{- end }}
+{{- with .Values.extraEnvYaml }}
+          {{- toYaml . | nindent 10 }}
+{{- end }}
+          ports:
+              - name: http
+                containerPort: {{ .Values.container.port }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          {{- end }}
+          {{- if .Values.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.extraVolumes }}
+      volumes:
+        {{- toYaml .Values.extraVolumes | nindent 10 }}
+      {{- end }}

--- a/dataset-service-hdc/templates/ingress.yaml
+++ b/dataset-service-hdc/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "dataset-service.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "dataset-service.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/dataset-service-hdc/templates/service.yaml
+++ b/dataset-service-hdc/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "dataset-service.fullname" . }}
+  labels:
+    {{- include "dataset-service.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+  selector:
+    {{- include "dataset-service.selectorLabels" . | nindent 4 }}

--- a/dataset-service-hdc/templates/service.yaml
+++ b/dataset-service-hdc/templates/service.yaml
@@ -4,11 +4,15 @@ metadata:
   name: {{ include "dataset-service.fullname" . }}
   labels:
     {{- include "dataset-service.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
+      name: {{ .Values.service.portName }}
   selector:
     {{- include "dataset-service.selectorLabels" . | nindent 4 }}

--- a/dataset-service-hdc/templates/serviceaccount.yaml
+++ b/dataset-service-hdc/templates/serviceaccount.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+{{- if .Values.imagePullSecrets }}
+imagePullSecrets:
+{{- range $key, $secret := .Values.imagePullSecrets }}
+  - name: {{ $secret.name }}
+{{- end }}
+{{- end }}
+kind: ServiceAccount
+metadata:
+  name: {{ include "dataset-service.serviceAccountName" . }}
+  labels:
+    {{- include "dataset-service.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/dataset-service-hdc/templates/tests/test-connection.yaml
+++ b/dataset-service-hdc/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "dataset-service.fullname" . }}-test-connection"
+  labels:
+    {{- include "dataset-service.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "dataset-service.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/dataset-service-hdc/values.yaml
+++ b/dataset-service-hdc/values.yaml
@@ -32,6 +32,12 @@ container:
 service:
   type: ClusterIP
   port: 80
+  portName: "http"
+  # Additional custom labels can be added to the service
+  # Example:
+  #labels:
+  #  prometheus.io/scrape: "true"
+  #  team: "backend"
 
 podAnnotations: {}
 
@@ -61,10 +67,10 @@ extraEnv: {}
 
 extraEnvYaml: {}
 
-readinessProbe: []
+readinessProbe: {}
 
 extraVolumeMounts: []
 
 extraVolumes: []
 
-updateStrategy: []
+updateStrategy: {}

--- a/dataset-service-hdc/values.yaml
+++ b/dataset-service-hdc/values.yaml
@@ -1,0 +1,70 @@
+# Default values for dataset-service.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+nameOverride: ""
+fullnameOverride: ""
+
+replicaCount: 1
+
+image:
+  repository: dataset
+  tag: 25
+  pullPolicy: Always
+
+appConfig:
+  port: 5081
+  env: "dev"
+  config_center_enabled: false
+  config_center_base_url: http://common.utility:5062/
+  srv_namespace: service_dataset
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: false
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: 
+
+container:
+  port: 5081
+
+service:
+  type: ClusterIP
+  port: 80
+
+podAnnotations: {}
+
+deploymentAnnotations: {}
+
+podSecurityContext: {}
+
+securityContext: {}
+
+imagePullSecrets: []
+
+ingress:
+  enabled: false
+
+resources: {}
+
+autoscaling:
+  enabled: false
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+extraEnv: {}
+
+extraEnvYaml: {}
+
+readinessProbe: []
+
+extraVolumeMounts: []
+
+extraVolumes: []
+
+updateStrategy: []


### PR DESCRIPTION
There are 3 commits in this PR. 

## 1st commit message
This chart is added by extracting the files from version 0.4.0.

## 2nd commit
IEBH-319: add new features to service.yaml in dataset

- Bump Helm chart version from 0.4.0 to 0.5.0;
- Add support for custom labels in `service.yaml` via `service.labels` in `values.yaml`;
- Define `portName` in service configuration so that Prometheus
  ServiceMonitors can reach the port;
- Replace empty arrays with objects in `values.yaml` for `readinessProbe` and `updateStrategy` fields to reflect expected key-value structures

## 3rd commit
IEBH-320: enable change of bff service port name

Whith this commit we are allowing people to change the service port name
to whatever they want via values file.