### PR TITLE
chore: replace bitnami image references with soldevelo equivalents

### DIFF
--- a/docs/index.yaml
+++ b/docs/index.yaml
@@ -2446,7 +2446,7 @@ entries:
         - name: elasticsearch-exporter
           image: docker.io/bitnami/elasticsearch-exporter:1.7.0-debian-12-r36
         - name: os-shell
-          image: docker.io/bitnami/os-shell:12-debian-12-r30
+          image: docker.io/soldevelo/os-shell:12-debian-12-r2
       licenses: Apache-2.0
     apiVersion: v2
     appVersion: 8.15.1
@@ -3791,11 +3791,11 @@ entries:
         - name: jmx-exporter
           image: docker.io/bitnami/jmx-exporter:1.0.1-debian-12-r9
         - name: kafka
-          image: docker.io/bitnami/kafka:3.9.0-debian-12-r1
+          image: docker.io/soldevelo/kafka:3.9.2-debian-12-r0
         - name: kubectl
           image: docker.io/bitnami/kubectl:1.31.2-debian-12-r6
         - name: os-shell
-          image: docker.io/bitnami/os-shell:12-debian-12-r33
+          image: docker.io/soldevelo/os-shell:12-debian-12-r2
       licenses: Apache-2.0
     apiVersion: v2
     appVersion: 3.9.0
@@ -7186,7 +7186,7 @@ entries:
       category: Database
       images: |
         - name: os-shell
-          image: docker.io/bitnami/os-shell:12-debian-12-r24
+          image: docker.io/soldevelo/os-shell:12-debian-12-r2
         - name: postgres-exporter
           image: docker.io/bitnami/postgres-exporter:0.15.0-debian-12-r36
         - name: postgresql
@@ -7961,7 +7961,7 @@ entries:
         - name: kubectl
           image: docker.io/bitnami/kubectl:1.30.2-debian-12-r2
         - name: os-shell
-          image: docker.io/bitnami/os-shell:12-debian-12-r24
+          image: docker.io/soldevelo/os-shell:12-debian-12-r2
         - name: redis
           image: docker.io/bitnami/redis:7.2.5-debian-12-r2
         - name: redis-exporter
@@ -8627,7 +8627,7 @@ entries:
       category: Analytics
       images: |
         - name: os-shell
-          image: docker.io/bitnami/os-shell:12-debian-12-r50
+          image: docker.io/soldevelo/os-shell:12-debian-12-r2
         - name: thanos
           image: docker.io/bitnami/thanos:0.39.2-debian-12-r1
       licenses: Apache-2.0


### PR DESCRIPTION
## Why this change

Bitnami moved image updates behind a paywall on August 28 2025, and public images no longer receive ongoing updates.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements with active support.

## Image replacements

- `bitnami/os-shell:12-debian-12-r30` → [`soldevelo/os-shell:12-debian-12-r2`](https://hub.docker.com/r/soldevelo/os-shell)
- `bitnami/kafka:3.9.0-debian-12-r1` → [`soldevelo/kafka:3.9.2-debian-12-r0`](https://hub.docker.com/r/soldevelo/kafka)
- `bitnami/os-shell:12-debian-12-r33` → [`soldevelo/os-shell:12-debian-12-r2`](https://hub.docker.com/r/soldevelo/os-shell)
- `bitnami/os-shell:12-debian-12-r24` → [`soldevelo/os-shell:12-debian-12-r2`](https://hub.docker.com/r/soldevelo/os-shell)
- `bitnami/os-shell:12-debian-12-r50` → [`soldevelo/os-shell:12-debian-12-r2`](https://hub.docker.com/r/soldevelo/os-shell)